### PR TITLE
fix ELF.compareOverlay

### DIFF
--- a/die_source/scriptelf.cpp
+++ b/die_source/scriptelf.cpp
@@ -356,7 +356,7 @@ QString scriptELF::getSectionName(int nSection)
 
 bool scriptELF::compareOverlay(QString sSignature, unsigned int nOffset)
 {
-    return compareOverlay(sSignature,nOffset);
+    return elffile->compareOverlay(sSignature,nOffset);
 }
 
 long long scriptELF::getEntryPointOffset()


### PR DESCRIPTION
Detect It Easy падает при использование ELF.compareOverlay

// DIE's signature file
init("compiler","test");
function detect(bShowType,bShowVersion,bShowOptions)
{
    if(ELF.compareOverlay("test"))
    {
        bDetected=1;
    }
    return result(bShowType,bShowVersion,bShowOptions);
}