### PR TITLE
Fix the missing window icon when running under Wayland

### DIFF
--- a/gui_source/main_gui.cpp
+++ b/gui_source/main_gui.cpp
@@ -50,7 +50,10 @@ int main(int argc, char *argv[])
     }
 
     XSingleApplication app(argc, argv);
+
+#ifdef Q_OS_LINUX
     app.setDesktopFileName("die");
+#endif
 
 #ifndef Q_OS_WIN
     QApplication::setWindowIcon(QIcon(":/images/main.png"));

--- a/gui_source/main_gui.cpp
+++ b/gui_source/main_gui.cpp
@@ -50,6 +50,7 @@ int main(int argc, char *argv[])
     }
 
     XSingleApplication app(argc, argv);
+    app.setDesktopFileName("die");
 
 #ifndef Q_OS_WIN
     QApplication::setWindowIcon(QIcon(":/images/main.png"));


### PR DESCRIPTION
Currently, when running under Wayland, the window icon will fallback to the default Wayland icon.
Setting the desktop filename can solve this problem.
Similar to https://github.com/horsicq/XAPKDetector/pull/9