### PR TITLE
Add github build pipeline

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -7,7 +7,9 @@ on:
 
 env:
   SRC_PATH: ${{ github.workspace }}/src
+  SRC_PATH_WIN: ${{ github.workspace }}\src
   RELEASE_PATH: ${{ github.workspace }}/src/release
+  RELEASE_PATH_WIN: ${{ github.workspace }}\src\release
 
 # the jobs are based on these notes:
 # https://github.com/horsicq/Detect-It-Easy/blob/master/docs/BUILD.md
@@ -141,7 +143,7 @@ jobs:
           set INNOSETUP_PATH="C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
 
           set X_BUILD_PREFIX="win32"
-          set X_SOURCE_PATH="${{ env.SRC_PATH }}"
+          set X_SOURCE_PATH="${{ env.SRC_PATH_WIN }}"
           for /f "delims=" %%x in ('type "%X_SOURCE_PATH%\release_version.txt"') do set X_RELEASE_VERSION=%%x
 
           echo on
@@ -181,8 +183,9 @@ jobs:
           set INNOSETUP_PATH="C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
 
           set X_BUILD_PREFIX="win64"
-          set X_SOURCE_PATH="${{ env.SRC_PATH }}"
+          set X_SOURCE_PATH="${{ env.SRC_PATH_WIN }}"
           for /f "delims=" %%x in ('type "%X_SOURCE_PATH%\release_version.txt"') do set X_RELEASE_VERSION=%%x
 
           echo on
           call "%X_SOURCE_PATH%\build_win_generic_check.cmd"
+

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -2,15 +2,118 @@ name: Build DIE-engine
 
 on:
   workflow_dispatch:
+  release:
+    types: [created]
 
+env:
+  SRC_PATH: ${{ github.workspace }}/src
+  RELEASE_PATH: ${{ github.workspace }}/src/release
+
+# the jobs are based on these notes:
+# https://github.com/horsicq/Detect-It-Easy/blob/master/docs/BUILD.md
 jobs:
+  build-ubuntu-22:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+         submodules: 'recursive'
+         path: ${{ env.SRC_PATH }}
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install qtbase5-dev qtscript5-dev qttools5-dev-tools libqt5svg5-dev qtchooser qt5-qmake build-essential -y
+
+      - name: Build
+        working-directory: ${{ env.SRC_PATH }}
+        run: |
+          bash -x build_dpkg.sh
+
+      - name: Upload Release as Artifact
+        if: github.event_name != 'release'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ubuntu22-artifact
+          path: |
+            ${{ env.RELEASE_PATH }}/*.deb
+
+      - name: Upload Release as Download
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: |
+            ${{ env.RELEASE_PATH }}/*.deb
+
+  build-ubuntu-20:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+         submodules: 'recursive'
+         path: ${{ env.SRC_PATH }}
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install qtbase5-dev qtscript5-dev qttools5-dev-tools libqt5svg5-dev qt5-default build-essential -y
+
+      - name: Build
+        working-directory: ${{ env.SRC_PATH }}
+        run: |
+          bash -x build_dpkg.sh
+
+      - name: Upload Release as Artifact
+        if: github.event_name != 'release'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ubuntu20-artifact
+          path: |
+            ${{ env.RELEASE_PATH }}/*.deb
+
+      - name: Upload Release as Download
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: |
+            ${{ env.RELEASE_PATH }}/*.deb
+
+  build-osx:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+         submodules: 'recursive'
+         path: ${{ env.SRC_PATH }}
+
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: '5.15.2'
+          host: 'mac'
+          target: 'desktop'
+          arch: 'clang_64'
+          # I make it match what build_mac.sh expects. Although I could also use Qt5_DIR
+          #dir: ${{ env.HOME }}
+          dir: /Users/runner
+          modules: qtscript
+
+      - name: Build
+        working-directory: ${{ env.SRC_PATH }}
+        run: |
+          bash -x build_mac.sh
+
   build-windows-32:
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v4
         with:
          submodules: 'recursive'
-         path: 'code'
+         path: ${{ env.SRC_PATH }}
 
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
@@ -19,7 +122,7 @@ jobs:
           vs-version: '[16.0,17.0)'
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@v3
+        uses: jurplel/install-qt-action@v4
         with:
           version: '5.15.2'
           host: 'windows'
@@ -28,16 +131,58 @@ jobs:
           dir: ${{ github.workspace }}
           modules: qtscript
 
-      - name: Setup environment variables and run build script
+      - name: Build
         shell: cmd
+        working-directory: ${{ env.SRC_PATH }}
         run: |
-          cd code
           set VSVARS_PATH="C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars32.bat"
           set QMAKE_PATH="${{ github.workspace }}\Qt\5.15.2\msvc2019\bin\qmake.exe"
           set SEVENZIP_PATH="C:\Program Files\7-Zip\7z.exe"
           set INNOSETUP_PATH="C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
+
           set X_BUILD_PREFIX="win32"
-          set X_SOURCE_PATH="${{ github.workspace }}\code"
+          set X_SOURCE_PATH="${{ env.SRC_PATH }}"
           for /f "delims=" %%x in ('type "%X_SOURCE_PATH%\release_version.txt"') do set X_RELEASE_VERSION=%%x
+
           echo on
-          call "%X_SOURCE_PATH%\build_win_generic.cmd"
+          call "%X_SOURCE_PATH%\build_win_generic_check.cmd"
+          
+  build-windows-64:
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v4
+        with:
+         submodules: 'recursive'
+         path: ${{ env.SRC_PATH }}
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+        with:
+          msbuild-architecture: x64
+          vs-version: '[16.0,17.0)'
+
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: '5.15.2'
+          host: 'windows'
+          target: 'desktop'
+          arch: 'win64_msvc2019_64'
+          dir: ${{ github.workspace }}
+          modules: qtscript
+
+      - name: Build
+        shell: cmd
+        working-directory: ${{ env.SRC_PATH }}
+        run: |
+          set VSVARS_PATH="C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          set QMAKE_PATH="${{ github.workspace }}\Qt\5.15.2\msvc2019_64\bin\qmake.exe"
+          set SEVENZIP_PATH="C:\Program Files\7-Zip\7z.exe"
+          set INNOSETUP_PATH="C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
+
+          set X_BUILD_PREFIX="win64"
+          set X_SOURCE_PATH="${{ env.SRC_PATH }}"
+          for /f "delims=" %%x in ('type "%X_SOURCE_PATH%\release_version.txt"') do set X_RELEASE_VERSION=%%x
+
+          echo on
+          call "%X_SOURCE_PATH%\build_win_generic_check.cmd"

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -143,7 +143,7 @@ jobs:
           set INNOSETUP_PATH="C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
 
           set X_BUILD_PREFIX="win32"
-          set X_SOURCE_PATH="${{ env.SRC_PATH_WIN }}"
+          set X_SOURCE_PATH=${{ env.SRC_PATH_WIN }}
           for /f "delims=" %%x in ('type "%X_SOURCE_PATH%\release_version.txt"') do set X_RELEASE_VERSION=%%x
 
           echo on
@@ -183,7 +183,7 @@ jobs:
           set INNOSETUP_PATH="C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
 
           set X_BUILD_PREFIX="win64"
-          set X_SOURCE_PATH="${{ env.SRC_PATH_WIN }}"
+          set X_SOURCE_PATH=${{ env.SRC_PATH_WIN }}
           for /f "delims=" %%x in ('type "%X_SOURCE_PATH%\release_version.txt"') do set X_RELEASE_VERSION=%%x
 
           echo on

--- a/build_dpkg.sh
+++ b/build_dpkg.sh
@@ -1,4 +1,9 @@
 #!/bin/bash -x
+
+# Enable 'set -e' to ensure the script exits immediately if any command returns a non-zero exit code.
+# This is particularly useful so that github can correctly indicate the status of the process!
+set -e
+
 export QMAKE_PATH=/usr/bin/qmake
 
 export X_SOURCE_PATH=$PWD

--- a/build_mac.sh
+++ b/build_mac.sh
@@ -1,4 +1,9 @@
 #!/bin/sh -x
+
+# Enable 'set -e' to ensure the script exits immediately if any command returns a non-zero exit code.
+# This is particularly useful so that github can correctly indicate the status of the process!
+set -e
+
 export QMAKE_PATH=$HOME/Qt/5.15.2/clang_64/bin/qmake
 
 export X_SOURCE_PATH=$PWD


### PR DESCRIPTION
The pipeline works as follows:
* If run manually from actions when it finishes the process attaches as artifacts the build. This is useful for testing.
* If you make a release it runs automatically and attaches the files to the release as a download.
* The pipeline runs on the images provided by github which are for: win, mac and ubuntu. For the rest of the OS could be done with jobs using the ubuntu image that has docker installed... and taking advantage of that try to do the rest of the builds.

Other clarifications:
* The branch master is no longer compiling for me, so the tests are repeated against the tag of the latest stable version.
* Ubuntu is completely finished (that's why it has the added steps to process the build).
* In windows it is necessary to make some adjustment of paths that from what I noticed are failing the check_file. I left a fix in this branch but I never saw the result so I don't know if the build is finished.
* Mac still doesn't compile, I will try to run the steps manually on my work mac to see if I understand why.

I leave the pr open to be working on it here.
Test run (tag 3.09 + this patch): https://github.com/xchwarze/DIE-engine/actions/runs/9932527015