### PR TITLE
Add `Keywords` field for better searching support

### DIFF
--- a/LINUX/io.github.horsicq.detect-it-easy.desktop
+++ b/LINUX/io.github.horsicq.detect-it-easy.desktop
@@ -6,4 +6,5 @@ Exec=die %F
 Icon=io.github.horsicq.detect-it-easy
 Categories=Development;
 MimeType=application/octet-stream;
+Keywords=die;
 StartupWMClass=die


### PR DESCRIPTION
Adding `Keywords` field makes users be able to search the app with specific keywords in linux, which can be convenient.
If we add the keyword `die`, users can search it with `die` keyword in the app menu or something like that.