### PR TITLE
Use `%f` to specify that `die` can only handle one argument

### DIFF
--- a/LINUX/io.github.horsicq.detect-it-easy.desktop
+++ b/LINUX/io.github.horsicq.detect-it-easy.desktop
@@ -2,7 +2,7 @@
 Type=Application
 Name=Detect It Easy
 Comment=Advanced file analyzer
-Exec=die %F
+Exec=die %f
 Icon=io.github.horsicq.detect-it-easy
 Categories=Development;
 MimeType=application/octet-stream;


### PR DESCRIPTION
Here's what [the doc](https://specifications.freedesktop.org/desktop-entry-spec/latest/exec-variables.html) says about `%f` field code:
>A single file name (including the path), even if multiple files are selected. The system reading the desktop entry should recognize that the program in question cannot handle multiple file arguments, and it should probably spawn and execute multiple copies of a program for each selected file if the program is not able to handle additional file arguments.

So I think we should use `%f` instead of `%F`.