### PR TITLE
Update PKGBUILD: install icons

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -13,9 +13,11 @@ conflicts=(
 )
 depends=(
   'freetype2'
+  'gcc-libs'
   'glib2'
   'glibc'
   'graphite'
+  'hicolor-icon-theme'
   'icu'
   'krb5'
   'qt5-base'
@@ -24,9 +26,7 @@ depends=(
   'systemd-libs'
 )
 makedepends=(
-  'coreutils'
   'git'
-  'imagemagick'
   'qt5-tools'
 )
 _srcname="DIE-engine"
@@ -43,8 +43,8 @@ _bold='\e[1m'
 _prefix=" ${_bold}${_color}==>${_stop} "
 
 prepare() {
-    cd "$srcdir/$_srcname"
-    git submodule update --init --recursive
+  cd "$srcdir/$_srcname"
+  git submodule update --init --recursive
 }
 
 build() {
@@ -76,7 +76,7 @@ package() {
   cd "$_srcname" || return
 
   echo -e "${_prefix}Creating the package base"
-  install -d "$pkgdir"/{opt/"${_pkgname}",usr/bin,usr/share/pixmaps}
+  install -d "$pkgdir"/{opt/"${_pkgname}",usr/bin,usr/share/icons}
   install -d "$pkgdir/opt/${_pkgname}"/{lang,qss,info,db,signatures,images,yara_rules}
 
   echo -e "${_prefix}Copying the package binaries"
@@ -98,9 +98,12 @@ package() {
   ln -s /opt/"${_pkgname}"/diec "$pkgdir"/usr/bin/diec
   ln -s /opt/"${_pkgname}"/diel "$pkgdir"/usr/bin/diel
 
+  echo -e "${_prefix}Setting up desktop icons"
+  cp -r LINUX/hicolor "$pkgdir"/usr/share/icons
+
   echo -e "${_prefix}Setting up desktop shortcuts"
   install -Dm 644 LINUX/io.github.horsicq.detect-it-easy.desktop -t "$pkgdir"/usr/share/applications
-  
+
   echo -e "${_prefix}Setting up metainfo file"
   install -Dm 644 LINUX/io.github.horsicq.detect-it-easy.metainfo.xml -t "$pkgdir"/usr/share/metainfo
   


### PR DESCRIPTION
Hello, thanks for adding me as an AUR co-maintainer.

I checked the package and found icons are missing, so I added them.

---

I removed some makedepends:
- `coreutils`: removed because it's in the `base` group, and it's a dependency of `pacman`, it's assumed to be already installed. https://wiki.archlinux.org/title/PKGBUILD#makedepends
- `imagemagick`: removed because we don't use it to convert the size of icons anymore

---

These dependency are included, but may not be needed:

- freetype2
- glib2
- graphite
- icu
- krb5
- qt5-svg
- systemd-libs

Should I remove these dependencies from the PKGBUILD, or are they required for some optional features?
