### PR TITLE
Improve high DPI scaling for Qt ≥ 5.14

### DIFF
--- a/gui_source/main_gui.cpp
+++ b/gui_source/main_gui.cpp
@@ -29,6 +29,9 @@ int main(int argc, char *argv[])
 #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    QApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
+#endif
 #ifdef Q_OS_MAC
 #ifndef QT_DEBUG
     QString sLibraryPath = QString(argv[0]);


### PR DESCRIPTION
By setting rounding policy to PassThrough for Qt ≥ 5.14