### PR TITLE
fix(mac): rely on qt.conf for plugin discovery

### DIFF
--- a/src/gui/main_gui.cpp
+++ b/src/gui/main_gui.cpp
@@ -32,14 +32,6 @@ int main(int argc, char *argv[])
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     QApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
 #endif
-#ifdef Q_OS_MAC
-#ifndef QT_DEBUG
-    QString sLibraryPath = QString(argv[0]);
-    sLibraryPath = sLibraryPath.remove("MacOS/DiE") + "PlugIns";
-    QCoreApplication::setLibraryPaths(QStringList(sLibraryPath));
-#endif
-#endif
-
     QCoreApplication::setOrganizationName(X_ORGANIZATIONNAME);
     QCoreApplication::setOrganizationDomain(X_ORGANIZATIONDOMAIN);
     QCoreApplication::setApplicationName(X_APPLICATIONNAME);

--- a/src/lite/main_lite.cpp
+++ b/src/lite/main_lite.cpp
@@ -27,14 +27,6 @@ int main(int argc, char *argv[])
 #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
-#ifdef Q_OS_MAC
-#ifndef QT_DEBUG
-    QString sLibraryPath = QString(argv[0]);
-    sLibraryPath = sLibraryPath.remove("MacOS/DiEL") + "PlugIns";
-    QCoreApplication::setLibraryPaths(QStringList(sLibraryPath));
-#endif
-#endif
-
     QCoreApplication::setOrganizationName(X_ORGANIZATIONNAME);
     QCoreApplication::setOrganizationDomain(X_ORGANIZATIONDOMAIN);
     // Deliberately X_APPLICATIONNAME, not X_APPLICATIONNAMELITE: this is the


### PR DESCRIPTION
fixes #184

hey, this removes the old release-only macos library path overrides from both gui entry points.

those blocks parse argv[0] using the old qmake-era `MacOS/DiE` and `MacOS/DiEL` executable names. the current cmake targets produce lowercase `die` and `diel`, so the parsing creates paths such as `diePlugIns` and also replaces qt's normal library path list.

macdeployqt already writes `Contents/Resources/qt.conf` with `Plugins = PlugIns`, so both applications can use qt's normal plugin discovery instead.

tested with:

- clean arm64 release build using the macos 26.5 sdk, deployment target 26.0, and qt 6.11.1
- both die and diel compiled and linked
- direct die.app launch on macos 27 stayed alive for eight seconds
- qt loaded cocoa from `Contents/PlugIns/platforms/libqcocoa.dylib`
- both changed entry points compiled against the macos 27 sdk
