### PR TITLE
fix(mac): deploy bundled diec with qt

### DIFF
--- a/build_mac.sh
+++ b/build_mac.sh
@@ -53,9 +53,15 @@ cp -Rf "$X_SOURCE_PATH/dep/XYara/yara_rules"        "$RESOURCES/"
 cp -Rf "$X_SOURCE_PATH/images"                  "$RESOURCES/"
 [ -f "$X_SOURCE_PATH/dep/signatures/crypto.db" ]   && cp -f "$X_SOURCE_PATH/dep/signatures/crypto.db" "$RESOURCES/signatures/"
 
-# Copy diec into the bundle
-DIEC_BIN=$(find "$BUILD_DIR/src/console" -maxdepth 2 -name "diec" -type f | head -1)
-[ -n "$DIEC_BIN" ] && cp -f "$DIEC_BIN" "$APP_BUNDLE/Contents/MacOS/"
+# Copy diec into its final bundle location before the last deployment pass.
+DIEC_BIN=$(find "$BUILD_DIR/src/console" -maxdepth 2 -name "diec" -type f -print -quit)
+if [ -z "$DIEC_BIN" ]; then
+    echo "ERROR: diec not found under $BUILD_DIR/src/console" >&2
+    exit 1
+fi
+
+BUNDLED_DIEC="$APP_BUNDLE/Contents/MacOS/diec"
+cp -f "$DIEC_BIN" "$BUNDLED_DIEC"
 
 # macdeployqt (handled by cmake POST_BUILD, but run again as safety net)
 MACDEPLOYQT=""
@@ -66,9 +72,15 @@ do
     [ -x "$candidate" ] && MACDEPLOYQT="$candidate" && break
 done
 
-if [ -n "$MACDEPLOYQT" ]; then
-    "$MACDEPLOYQT" "$APP_BUNDLE" -always-overwrite
+if [ -z "$MACDEPLOYQT" ]; then
+    echo "ERROR: macdeployqt not found under $QT_PREFIX_PATH" >&2
+    exit 1
 fi
+
+# Both Qt 5 and Qt 6 require non-main executables to be listed explicitly.
+"$MACDEPLOYQT" "$APP_BUNDLE" \
+    "-executable=$BUNDLED_DIEC" \
+    -always-overwrite
 
 PACKAGE_DIR="$RELEASE_DIR/$X_BUILD_NAME"
 rm -rf "$PACKAGE_DIR"


### PR DESCRIPTION
fixes #185

hey, this makes the bundled diec part of the final macdeployqt pass.

build_mac.sh now:

- requires diec to exist instead of silently packaging without it
- copies it into its final `Contents/MacOS/diec` location
- requires macdeployqt to be available
- passes diec through `-executable=<path>` during the final deployment pass

small correction to my original report: a clean rerun with the actual diec showed that the explicit `-executable` pass is sufficient here. it rewrote both the qt dependencies and rpath bundle-relatively. the larger install/staging proposal is still useful hardening, but it is not required for this specific fix.

tested with qt 6.11.1:

- all qt dependencies use `@loader_path/../Frameworks`
- LC_RPATH is `@loader_path/../Frameworks`
- no homebrew, user, or temporary build prefix remains
- `diec --version` prints `die 4.0.0`
- a json scan of `/bin/ls` succeeds using the bundled database

the same `-executable=<path>` argument form is supported by both qt 5.15 and qt 6 macdeployqt. this change deliberately leaves the broader signing and archive behavior unchanged.
