### PR TITLE
fix(mac): preserve symlinks in portable archive

### DIFF
--- a/build_mac.sh
+++ b/build_mac.sh
@@ -77,6 +77,7 @@ cp -R "$APP_BUNDLE" "$PACKAGE_DIR/"
 
 cd "$RELEASE_DIR"
 ZIP_NAME="die_${X_RELEASE_VERSION}_mac_portable.zip"
-zip -r "$ZIP_NAME" "$X_BUILD_NAME"
+rm -f "$ZIP_NAME"
+zip -y -r "$ZIP_NAME" "$X_BUILD_NAME"
 rm -rf "$PACKAGE_DIR"
 echo "Created: $RELEASE_DIR/$ZIP_NAME"


### PR DESCRIPTION
fixes #190

hey, this recreates the macos portable zip before packaging and enables info-zip's symlink mode.

plain `zip -r` dereferences the symlinks inside deployed qt frameworks. after extraction, the framework layout is ambiguous and the previously valid app no longer passes strict signature verification.

both changes are needed:

- removing the old zip prevents stale entries from surviving an earlier package
- `-y` stores framework symlinks as symlinks

verified with an actual arm64 qt 6.11.1 app built against the macos 26.5 sdk:

- 54/54 framework symlinks and their exact targets survive
- extraction passes with `/usr/bin/unzip` and `ditto -x -k`
- `codesign --verify --deep --strict` passes after both extractions
- there are no broken symlinks
- `diec --version` returns `die 4.0.0`
- the top-level `die_mac_portable/` layout is unchanged
- two clean archive runs were byte-identical

this remains separate from the diec deployment change in #188.
